### PR TITLE
support rosdep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ Release
 
 # hook
 script/on-build-failed.bash
+
+# rosdep
+repos/rosdep/*
+!repos/rosdep/.gitkeep

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Build debian package from ROS2 package, and create apt repository for distributi
 Run the following commands.
 
 ```sh
-$ cd docker/
-$ docker build --build-arg USERNAME=$(whoami) --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) . -t ros2-deb-builder:galactic
+cd docker/
+docker build --build-arg USERNAME=$(whoami) --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) . -t ros2-deb-builder:galactic
 ```
 
 ## Prepare for Building
@@ -31,8 +31,8 @@ This build tool uses vcs to pull repositories, and the target file is `ws_galact
 Run the following commands.
 
 ```sh
-$ cd {path_to_ros2_deb_builder}
-$ docker run -it \
+cd {path_to_ros2_deb_builder}
+docker run -it \
   -v /home/$(whoami)/.ssh:/home/$(whoami)/.ssh \
   -v `pwd`:/home/$(whoami)/ros2_deb_builder ros2-deb-builder:galactic
 ```
@@ -42,8 +42,8 @@ $ docker run -it \
 Since the previous steps have already created apt repository, all you need to do is just run http server. One of the simple ways is to use nginx docker container.
 
 ```sh
-$ cd {path_to_ros2_deb_builder}
-$ docker run -d --rm -v `pwd`/repos:/usr/share/nginx/html:ro -p 80:80 nginx
+cd {path_to_ros2_deb_builder}
+docker run -d --rm -v `pwd`/repos:/usr/share/nginx/html:ro -p 80:80 nginx
 ```
 
 ## Access apt repository

--- a/doc/apt-repo-setup.md
+++ b/doc/apt-repo-setup.md
@@ -7,15 +7,15 @@ Following instructions add your localhost apt repository to your hostmachine. IP
 1. Update the `apt` package index and install packages.
 
 ```sh
-$ sudo apt-get update
-$ sudo apt-get install curl gnupg
+sudo apt-get update
+sudo apt-get install curl gnupg
 ```
 
 2. Import the public key from the apt repository
 
 ```sh
-$ sudo mkdir -p /etc/apt/keyrings
-$ curl -fsSL http://localhost/gpg/sample.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/sample.gpg
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL http://localhost/gpg/sample.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/sample.gpg
 ```
 
 3. Use the following command to set up the repository (currently only `amd64` of Ubuntu 20.04 is supported)
@@ -29,13 +29,13 @@ echo \
 4. Update the `apt` package index
 
 ```sh
-$ sudo apt-get update
+sudo apt-get update
 ```
 
 If you don't receive any errors, you can now install any packages from apt repository.
 
 ```sh
-$ sudo apt-get install ros-galactic-h6x-internship-gazebo
+sudo apt-get install ros-galactic-h6x-internship-gazebo
 ```
 
 ## Add rosdep source
@@ -44,6 +44,7 @@ The following command adds rosdep source so that rosdep can resolve rosdep keys 
 
 ```sh
 echo "yaml http://localhost/rosdep/my_rosdep.yaml" | sudo tee /etc/ros/rosdep/sources.list.d/50-my-packages.list
+rosdep update
 ```
 
 

--- a/doc/apt-repo-setup.md
+++ b/doc/apt-repo-setup.md
@@ -1,5 +1,7 @@
 # How to setup apt repository
 
+## Add apt source
+
 Following instructions add your localhost apt repository to your hostmachine. IP address or the name of gpg key might be different from yours, so please fix them if necessary.
 
 1. Update the `apt` package index and install packages.
@@ -35,3 +37,13 @@ If you don't receive any errors, you can now install any packages from apt repos
 ```sh
 $ sudo apt-get install ros-galactic-h6x-internship-gazebo
 ```
+
+## Add rosdep source
+
+The following command adds rosdep source so that rosdep can resolve rosdep keys of this repository's packages.
+
+```sh
+echo "yaml http://localhost/rosdep/my_rosdep.yaml" | sudo tee /etc/ros/rosdep/sources.list.d/50-my-packages.list
+```
+
+

--- a/script/pool-deb.bash
+++ b/script/pool-deb.bash
@@ -7,4 +7,6 @@ find $REPOS_DIR/pool/main/ -name \*.deb -exec rm {} \;
 find $WS_GALACTIC/src/ -name \*.deb -exec cp {} $REPOS_DIR/pool/main/ \;
 find $EXT_DIR -name \*.deb -exec cp {} $REPOS_DIR/pool/main/ \;
 
+cp $WS_GALACTIC/my_rosdep.yaml $REPOS_DIR/rosdep/my_rosdep.yaml
+
 echo "pool-deb.bash: DONE"


### PR DESCRIPTION
Since rosdep source is not available for the ordinary users of the apt repository, they cannot use `rosdep install` to install packages.
So this pull request copies the yaml file to `repos/rosdep/` to distribute to everyone, and it also adds the instruction of how to add rosdep source.