### PR TITLE
Specify rosdistro 'galactic' in rosdep update

### DIFF
--- a/doc/apt-repo-setup.md
+++ b/doc/apt-repo-setup.md
@@ -45,5 +45,5 @@ The following command adds rosdep source so that rosdep can resolve rosdep keys 
 ```sh
 echo "yaml http://localhost/rosdep/my_rosdep.yaml" \
   | sudo tee /etc/ros/rosdep/sources.list.d/50-my-packages.list > /dev/null
-rosdep update
+rosdep update --rosdistro galactic
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /home/$USERNAME
 # setup ros galactic
 RUN . /opt/ros/galactic/setup.sh \
  && sudo rosdep init \
- && rosdep update
+ && rosdep update --rosdistro galactic
 
 # set env
 ENV WS_GALACTIC /home/$USERNAME/ros2_deb_builder/ws_galactic

--- a/script/update-rosdep.bash
+++ b/script/update-rosdep.bash
@@ -16,7 +16,7 @@ for NAME in $PKG_NAME_LIST; do
 done
 
 echo "yaml file://$(pwd)/my_rosdep.yaml" | sudo tee /etc/ros/rosdep/sources.list.d/50-my-packages.list
-rosdep update
+rosdep update --rosdistro galactic
 sudo apt-get update
 rosdep install -y -i --from-path ./src
 


### PR DESCRIPTION
Since `galactic` has become end-of-life, default behavior of `rosdep update` skips `galactic` and it causes rosdep keys problems. This pull request adds `--rosdistro galactic` option to the command to avoid this problem.